### PR TITLE
Update the md5 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ readme = "README.md"
 [dependencies]
 byteorder = "1.0"
 fallible-iterator = "0.1"
-hex = "0.2"
-md5 = "0.2"
+md5 = "0.3"
 memchr = "1.0"

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,5 +1,4 @@
 //! Authentication protocol support.
-use hex::ToHex;
 use md5::Context;
 
 /// Hashes authentication information in a way suitable for use in response
@@ -14,9 +13,9 @@ pub fn md5_hash(username: &[u8], password: &[u8], salt: [u8; 4]) -> String {
     context.consume(username);
     let output = context.compute();
     context = Context::new();
-    context.consume(output.to_hex().as_bytes());
+    context.consume(format!("{:x}", output));
     context.consume(&salt);
-    format!("md5{}", context.compute().to_hex())
+    format!("md5{:x}", context.compute())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![warn(missing_docs)]
 extern crate byteorder;
 extern crate fallible_iterator;
-extern crate hex;
 extern crate md5;
 extern crate memchr;
 


### PR DESCRIPTION
The pull request is to update `md5`. It also eliminates `hex`.

Regards,
Ivan